### PR TITLE
added `none` exporter & minor bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <br/>
 
+## `0.10.1`
+- Added `none` exporter type.
+- Bug fix: Fixed incorrect return type for verifyOptions().
+
 ## `0.9.0`
 
 - Added unit tests for `ConfigFactory.js` & `AutoInstrumentMap.js`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-instrument",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "description": "Easy OpenTelemetry tracing instrumentation for Node.JS",
   "license": "LGPL-3.0-only",
   "author": {

--- a/src/tracing/EZInstrument.js
+++ b/src/tracing/EZInstrument.js
@@ -173,12 +173,14 @@ class EZInstrument {
                 resource: serviceResources
             });
 
-            nodeTraceProvider.addSpanProcessor(new BatchSpanProcessor(finalOptions.export.exporter, {
-                exportTimeoutMillis: finalOptions.export.batchSpanProcessorConfig.exportTimeoutMillis,
-                maxExportBatchSize: finalOptions.export.batchSpanProcessorConfig.maxExportBatchSize,
-                maxQueueSize: finalOptions.export.batchSpanProcessorConfig.maxQueueSize,
-                scheduledDelayMillis: finalOptions.export.batchSpanProcessorConfig.scheduledDelayMillis
-            }));
+            if(finalOptions.export.exporter !== null) {
+                nodeTraceProvider.addSpanProcessor(new BatchSpanProcessor(finalOptions.export.exporter, {
+                    exportTimeoutMillis: finalOptions.export.batchSpanProcessorConfig.exportTimeoutMillis,
+                    maxExportBatchSize: finalOptions.export.batchSpanProcessorConfig.maxExportBatchSize,
+                    maxQueueSize: finalOptions.export.batchSpanProcessorConfig.maxQueueSize,
+                    scheduledDelayMillis: finalOptions.export.batchSpanProcessorConfig.scheduledDelayMillis
+                }));
+            }
 
             if(finalOptions.export.enableConsoleExporter === true) {
                 nodeTraceProvider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));

--- a/src/tracing/EZInstrumentOptions.js
+++ b/src/tracing/EZInstrumentOptions.js
@@ -57,13 +57,13 @@ class EZInstrumentOptions {
          */
         url: "",
         /**
-         * Choose your type of exporter (http, grpc, etc.).
+         * Choose your type of exporter (none, http, grpc, etc.).
          *
-         * Defaults to OpenTelemetry's http exporter.
-         * @default "http"
-         * @type {("http" | "grpc" | "otel-http" | "otel-grpc")}
+         * Defaults to no exporter.
+         * @default "none"
+         * @type {("none" | "http" | "grpc" | "otel-http" | "otel-grpc")}
          */
-        exporterType: "http",
+        exporterType: "none",
         /**
          * Enables the ConsoleSpanExporter which prints all spans to the console.
          * @type {boolean}

--- a/src/tracing/FinalOptions.js
+++ b/src/tracing/FinalOptions.js
@@ -1,4 +1,6 @@
 const { DiagLogLevel } = require('@opentelemetry/api');
+const { OTLPTraceExporter: OTLPTraceExporterGrpc } = require('@opentelemetry/exporter-trace-otlp-grpc');
+const { OTLPTraceExporter: OTLPTraceExporterHttp } = require('@opentelemetry/exporter-trace-otlp-http');
 const { otelAutoInstrumentationMap } = require('./AutoInstrumentMap')
 
 class FinalOptions {
@@ -31,9 +33,12 @@ class FinalOptions {
          */
         url: null,
         /**
-         * @type {string|null}
+         * @type {string}
          */
         exporterType: null,
+        /**
+         * @type {null | OTLPTraceExporterHttp | OTLPTraceExporterGrpc}
+         */
         exporter: null,
         /**
          * @type {boolean}

--- a/src/tracing/FinalOptionsBuilder.js
+++ b/src/tracing/FinalOptionsBuilder.js
@@ -57,17 +57,20 @@ class FinalOptionsBuilder {
     /**
      * @private
      * @param {string} exporterType
-     * @param {string|null} exportUrl
+     * @param {string | null} exportUrl
+     * @returns {null | OTLPTraceExporterHttp | OTLPTraceExporterGrpc}
      */
      getExporter(exporterType, exportUrl) {
         exporterType = exporterType.toLowerCase();
-        if(exporterType === 'http' || exporterType === 'otel-http') {
+        if(exporterType === "none") {
+            logger.warn("ez-instrument: No exporter has been selected.");
+            return null;
+        } else if(exporterType === 'http' || exporterType === 'otel-http') {
             const { OTLPTraceExporter: OTLPTraceExporterHttp } = require('@opentelemetry/exporter-trace-otlp-http');
             const httpExporter = new OTLPTraceExporterHttp({
                 url: exportUrl
             });
             return httpExporter;
-
         } else if(exporterType === 'grpc' || exporterType === 'otel-grpc') {
             const { OTLPTraceExporter: OTLPTraceExporterGrpc } = require('@opentelemetry/exporter-trace-otlp-grpc');
             const grpcExporter = new OTLPTraceExporterGrpc({

--- a/src/tracing/FinalOptionsBuilder.js
+++ b/src/tracing/FinalOptionsBuilder.js
@@ -28,11 +28,11 @@ class FinalOptionsBuilder {
 
     /**
      * @private
-     * @param {FinalOptions} inputOptions
-     * @returns {FinalOptions}
+     * @param {EZInstrumentOptions} inputOptions
+     * @returns {EZInstrumentOptions}
      */
     verifyOptions(inputOptions) {
-        let _finalOptions = new FinalOptions();
+        let _finalOptions = new EZInstrumentOptions();
         if(inputOptions) {
             if(inputOptions.service) {
                 _finalOptions.service = inputOptions.service;


### PR DESCRIPTION
- Added a new `none` trace exporter which skips referencing a span processor to the trace provider
- Bug fix: incorrect function signature for `verifyOptions()`